### PR TITLE
Fix nginx http redirect to https

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,7 +8,7 @@ services:
     restart: always
     command: ["nginx", "-g", "daemon off;"]
     volumes:
-      - ./nginx/nginx.conf:/etc/nginx/conf.d/nginx.conf
+      - ./nginx/nginx.conf:/etc/nginx/conf.d/default.conf
       - ${CERT_PATH}:/etc/nginx/ssl/inception.crt
       - ${CERT_KEY_PATH}:/etc/nginx/ssl/inception.key
       - static_django_files:/static


### PR DESCRIPTION
The redirect in nginx.conf was already working, but default.conf still existed in the container and was included by the default nginx.conf. The default config in there was overriding our redirect. We're now mounting the `nginx.conf` over it to hide the config in `default.conf`.